### PR TITLE
Fixed export button in FireFox

### DIFF
--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -196,6 +196,7 @@
 					+ '-' + d.getFullYear() + '-' + (d.getMonth()+1) + '-' + d.getDate()
 					+ '-' + d.getHours() + '-' + d.getMinutes() + '-' + d.getSeconds()
 					+'.xls';
+				document.body.appendChild(dummy);
 				dummy.click();
 			},
 


### PR DESCRIPTION
With Firefox you have to explicitly add the link element to the DOM before you can execute click()